### PR TITLE
Update posture module

### DIFF
--- a/PSACompressor/Data/EventListView.txt
+++ b/PSACompressor/Data/EventListView.txt
@@ -583,7 +583,23 @@ Bone=\X, Y Translation=\X
 1
 Bone=\X, Z Translation=\X
 
+05050100
+1
+Size=\X
+
+05060300
+1
+X Rotation=\X, Y Rotation=\X, Z Rotation=\X
+
+05090300
+1
+X Position=\X, Y Position=\X, Z Position=\X
+
 050A0300
+1
+X Position=\X, Y Position=\X, Z Position=\X
+
+050B0300
 1
 X Position=\X, Y Position=\X, Z Position=\X
 

--- a/PSACompressor/Data/Events.txt
+++ b/PSACompressor/Data/Events.txt
@@ -300,11 +300,6 @@ Set Animation Frame
 Changes the current frame of the animation. Does not change the frame of the sub action (i.e. timers and such are unaffected). Works when used in articles that have assigned animations in the FitEtc file.
 1
 
-05000000
-Reverse Direction
-The object is now considered to be facing the other direction. It will not visually change direction until the current animation ends or is interrupted.
-
-
 06000D00
 Offensive Collision
 Generate an offensive collision bubble with the specified parameters. Helpful info: tinyurl.com/HitboxParam
@@ -1047,6 +1042,11 @@ Sub Action Animation Offset
 Offsets a Change Sub Action command by what's specified in this command.
 0
 
+05000000
+Reverse Direction
+The object is now considered to be facing the other direction. It will not visually change direction until the current animation ends or is interrupted.
+
+
 05010000
 Left Direction
 Sets the character's direction to the left. The effect occurs when the current Action is changed. To change the direction immediately, "Decide Direction" is required.
@@ -1067,14 +1067,34 @@ Decide Direction
 Immediately changes the direction of the character in the direction set by "Set Direction" and similar commands.
 
 
-05070300
-Posture 07
-Unknown.
+05050100
+Change Model Size
+Change the character size. Resizing by this event does not change the ability or damage done. Also, when get an item that changes size such as mushrooms, it will change from the base size. (In other words, the size changed by this event will be invalid.)
+1
 
+05060300
+Rotate Character Model
+Rotates character's model by amount specified. Persists until changed.
+111
 
-050D0100
-Posture 0D
-Unknown.
+05090300
+Set Character Position
+Teleport to the specified position based on the stage. Normally, unaffected by terrain. However, usually cannot move normally during ground actions. (Even during ground action, if the specified position exceeds the boundary, it will self-destruct)
+111
+
+050A0300
+Set Character Position 2
+Teleport to the specified position based on the stage. If there are walls, floors, or ceilings before to the specified position, There is a case that stops at that place. And, usually cannot move normally during ground actions. (Even during ground action, if the specified position exceeds the boundary, it will self-destruct)
+111
+
+050B0300
+Set Character Position (Relative)
+Teleport to the specified position based on the character position. If there are walls, floors, or ceilings before to the specified position, There is a case that stops at that place. And, usually cannot move normally during ground actions. (Even during ground action, if the specified position exceeds the boundary, it will self-destruct)
+111
+
+050C0000
+Reverse Model Direction (Transient)
+Reverse Model Direction. This effect ends when current action is changed.
 
 
 06020200
@@ -1414,11 +1434,6 @@ Terminate Independent Subroutine (Custom)
 Stops a running independent subroutine. (Requires the relevant code by Mawootad.)
 2
 
-05060300
-Rotate Character Model
-Rotates character's model by amount specified
-111
-
 12200200
 Attribute Range Set (Custom)
 Requires the On the Fly Attribute Modification code by Mawootad.
@@ -1624,11 +1639,6 @@ Translates the given bone on the Y-axis.
 Set Bone Translation (Z)
 Translates the given bone on the Z-axis.
 01
-
-050A0300
-Set Character Position
-Sets the character's current stage position.
-111
 
 1C000200
 Set Hitlag

--- a/PSACompressor/Data/Parameters.txt
+++ b/PSACompressor/Data/Parameters.txt
@@ -1438,14 +1438,6 @@ Location of the subroutine code to be ran.
 Thread ID
 ID of the thread to be terminated.
 
-05060300
-X
-Amount to rotate model on X Axis
-Y
-Amount to rotate model on Y Axis
-Z
-Amount to rotate model on Z Axis
-
 12200200
 Value
 The value to set the variable(s) to.
@@ -1874,13 +1866,41 @@ The bone to use for this command.
 Z Translation
 How much this bone will translate on the Z-axis.
 
+05050100
+Size
+Character size after changed.
+
+05060300
+X Rotation
+Amount to rotate the model on the X-Axis.
+Y Rotation
+Amount to rotate the model on the Y-Axis.
+Z Rotation
+Amount to rotate the model on the Z-Axis.
+
+05090300
+X Position
+Where to place the character on the X-axis. 0 is not always the center of the stage. Can surely go to the center of the stage by getting the left and right boundaries. (Snake's FS Exit = Center position / Dragoon Exit = Revival platform position) However, when using in Subspace, these variables may not be available.
+Y Position
+Where to place the character on the Y-axis. On most stages, 0 is closer to below the center. When go to the top of the stage, IC-Basic[30] (CameraLimit-Top) or IC-Basic[34] (DeadLine-Top) is useful. (Snake's FS Exit = IC-Basic[30] / Dragoon Exit = IC-Basic[34]) However, when using in Subspace, these variables may not be available.
+Z Position
+Where to place the character on the Z-axis. Normally set to 0. You can check the operation only when Set Air/Ground: Stop (0x32) was pre-loaded.
+
 050A0300
 X Position
 Where to place the character on the X-axis.
 Y Position
 Where to place the character on the Y-axis.
 Z Position
-Where to place the character on the Z-axis.
+Where to place the character on the Z-axis. Normally set to 0. You can check the operation only when Set Air/Ground: Stop (0x32) was pre-loaded.
+
+050B0300
+X Position
+How far to move the character on the X-axis.
+Y Position
+How far to move the character on the Y-axis.
+Z Position
+How far to move the character on the Z-axis. Normally set to 0. You can check the operation only when Set Air/Ground: Stop (0x32) was pre-loaded.
 
 04080300
 Animation Layer ID


### PR DESCRIPTION
All the missing events were pulled from PSA Compressor v0.45. Some were renamed to match convention.